### PR TITLE
[feat] Implement useDailogComponent (3H)

### DIFF
--- a/src/components/common/CommonDialog.tsx
+++ b/src/components/common/CommonDialog.tsx
@@ -16,6 +16,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { ExpandIcon } from "lucide-react";
 import { useState } from "react";
 
@@ -36,11 +37,8 @@ export default function CommonDialog({
   scale,
   contentStyleClass,
 }: CommonDialogProps) {
-  const DialogComponent = dialogType === "alert" ? AlertDialog : Dialog;
-  const DialogTriggerComponent =
-    dialogType === "alert" ? AlertDialogTrigger : DialogTrigger;
-  const DialogContentComponent =
-    dialogType === "alert" ? AlertDialogContent : DialogContent;
+  const { DialogComponent, DialogTriggerComponent, DialogContentComponent } =
+    useDialogComponent({ dialogType, type });
 
   const [isTooltipAllowed, setIsTooltipAllowed] = useState(true);
 

--- a/src/components/dialog/form/CheckBoxColumnForm/CheckBoxColumnForm.tsx
+++ b/src/components/dialog/form/CheckBoxColumnForm/CheckBoxColumnForm.tsx
@@ -1,7 +1,6 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
-import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -11,10 +10,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -47,6 +43,11 @@ const FormSchema = z.object({
 });
 
 export function CheckBoxColumnForm({ type }: CheckBoxColumnFormProps) {
+  const { DialogHeaderComponent, DialogTitleComponent } = useDialogComponent({
+    dialogType: "dialog",
+    type,
+  });
+
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),
     defaultValues: {
@@ -58,11 +59,6 @@ export function CheckBoxColumnForm({ type }: CheckBoxColumnFormProps) {
   const onSubmit = (data: z.infer<typeof FormSchema>) => {
     alert(data.items);
   };
-
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
 
   return (
     <CommonDialog type={type} title="Checkbox Column Form" scale={SCALE}>

--- a/src/components/dialog/form/InnerScrollForm/InnerScrollForm.tsx
+++ b/src/components/dialog/form/InnerScrollForm/InnerScrollForm.tsx
@@ -1,26 +1,15 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
 import {
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Form,
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
@@ -48,14 +37,12 @@ const formSchema = z.object({
 type FormData = z.infer<typeof formSchema>;
 
 export function InnerScrollForm({ type }: InnerScrollFormProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? DialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? DialogFooter : InlineDialogFooter;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+  } = useDialogComponent({ dialogType: "dialog", type });
 
   const form = useForm<FormData>({
     resolver: zodResolver(formSchema),

--- a/src/components/dialog/form/OpenSatisfactionSurveyForm/OpenSatisfactionSurveyForm.tsx
+++ b/src/components/dialog/form/OpenSatisfactionSurveyForm/OpenSatisfactionSurveyForm.tsx
@@ -1,24 +1,12 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
 import {
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Form,
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { RadioGroup } from "@/components/ui/radio-group";
@@ -30,6 +18,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { useForm } from "react-hook-form";
 
 interface SurveyFormData {
@@ -48,14 +37,12 @@ const SCALE = 0.65;
 export function OpenSatisfactionSurveyForm({
   type,
 }: OpenSatisfactionSurveyFormProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? DialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? DialogFooter : InlineDialogFooter;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+  } = useDialogComponent({ dialogType: "dialog", type });
 
   const form = useForm<SurveyFormData>({
     defaultValues: {

--- a/src/components/dialog/form/PaymentStepForm/PaymentStepForm.tsx
+++ b/src/components/dialog/form/PaymentStepForm/PaymentStepForm.tsx
@@ -1,26 +1,17 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
 import {
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Form,
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Progress } from "@/components/ui/progress";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { CheckCircle } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -48,12 +39,8 @@ interface PaymentStepFromProps {
 }
 
 export function PaymentStepForm({ type }: PaymentStepFromProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogFooterComponent =
-    type === "fullScreen" ? DialogFooter : InlineDialogFooter;
+  const { DialogHeaderComponent, DialogTitleComponent, DialogFooterComponent } =
+    useDialogComponent({ dialogType: "dialog", type });
 
   const [step, setStep] = useState<number>(1);
   const [progressValue, setProgressValue] = useState<number>(33);

--- a/src/components/dialog/form/RadioBoxColumnForm/RadioBoxColumnForm.tsx
+++ b/src/components/dialog/form/RadioBoxColumnForm/RadioBoxColumnForm.tsx
@@ -1,6 +1,5 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
-import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import {
   Form,
   FormControl,
@@ -9,11 +8,8 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -30,10 +26,10 @@ interface RadioBoxColumnFormProps {
 }
 
 export function RadioBoxColumnForm({ type }: RadioBoxColumnFormProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
+  const { DialogHeaderComponent, DialogTitleComponent } = useDialogComponent({
+    dialogType: "dialog",
+    type,
+  });
 
   const form = useForm<z.infer<typeof FormSchema>>({
     resolver: zodResolver(FormSchema),

--- a/src/components/dialog/form/SignInForm/SignInForm.tsx
+++ b/src/components/dialog/form/SignInForm/SignInForm.tsx
@@ -2,24 +2,15 @@ import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Form,
   FormControl,
   FormField,
   FormItem,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogDescription,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, EyeClosed } from "lucide-react";
 import { useState } from "react";
@@ -41,12 +32,11 @@ interface SignInFormProps {
 }
 
 export function SignInForm({ type }: SignInFormProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? DialogDescription : InlineDialogDescription;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+  } = useDialogComponent({ dialogType: "dialog", type });
 
   const [showPassword, setShowPassword] = useState(false);
 

--- a/src/components/dialog/form/SignUpForm/SignUpForm.tsx
+++ b/src/components/dialog/form/SignUpForm/SignUpForm.tsx
@@ -2,12 +2,6 @@ import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
   Form,
   FormControl,
   FormField,
@@ -15,14 +9,9 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import {
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Eye, EyeClosed } from "lucide-react";
 import { useState } from "react";
@@ -54,14 +43,12 @@ interface SignUpFormProps {
 }
 
 export function SignUpForm({ type }: SignUpFormProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? DialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? DialogFooter : InlineDialogFooter;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+  } = useDialogComponent({ dialogType: "dialog", type });
 
   const [showPassword, setShowPassword] = useState(false);
 

--- a/src/components/dialog/information/CreditsDialog/CreditsDialog.tsx
+++ b/src/components/dialog/information/CreditsDialog/CreditsDialog.tsx
@@ -6,19 +6,10 @@ import {
   AccordionTrigger,
 } from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
-import {
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  InlineDialogDescription,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
 import { Input } from "@/components/ui/input";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/hooks/use-toast";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { UserPlus, Users } from "lucide-react";
 
 interface CreditsDialogProps {
@@ -119,12 +110,11 @@ function RenderReferralSection() {
 }
 
 export function CreditsDialog({ type }: CreditsDialogProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? DialogDescription : InlineDialogDescription;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+  } = useDialogComponent({ dialogType: "dialog", type });
 
   return (
     <CommonDialog type={type} title="Credits Information" scale={SCALE}>

--- a/src/components/dialog/information/PricePlanDialog/PricePlanDialog.tsx
+++ b/src/components/dialog/information/PricePlanDialog/PricePlanDialog.tsx
@@ -1,10 +1,6 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Button } from "@/components/ui/button";
-import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import {
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { CheckIcon } from "lucide-react";
 import { useState } from "react";
 
@@ -53,10 +49,10 @@ const PRICING_PLANS = [
 export function PricePlanDialog({ type }: PricePlanDialogProps) {
   const [selected, setSelected] = useState("Free");
 
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
+  const { DialogHeaderComponent, DialogTitleComponent } = useDialogComponent({
+    dialogType: "dialog",
+    type,
+  });
 
   return (
     <CommonDialog

--- a/src/components/dialog/information/ReviewNCommentDialog/ReviewNCommentDialog.tsx
+++ b/src/components/dialog/information/ReviewNCommentDialog/ReviewNCommentDialog.tsx
@@ -1,16 +1,7 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Avatar } from "@/components/ui/avatar";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from "@/components/ui/dialog";
-import {
-  InlineDialogDescription,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { CircleUserIcon, Heart, Star } from "lucide-react";
 
 const comments = [
@@ -31,12 +22,11 @@ interface ReviewNCommentDialogProps {
 const SCALE = 0.5;
 
 export function ReviewNCommentDialog({ type }: ReviewNCommentDialogProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? DialogDescription : InlineDialogDescription;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+  } = useDialogComponent({ dialogType: "dialog", type });
 
   return (
     <CommonDialog type={type} title="Review & Comments" scale={SCALE}>

--- a/src/components/dialog/information/UserProfileDialog/UserProfileDialog.tsx
+++ b/src/components/dialog/information/UserProfileDialog/UserProfileDialog.tsx
@@ -1,11 +1,7 @@
 import CommonDialog from "@/components/common/CommonDialog";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Button } from "@/components/ui/button";
-import { DialogHeader, DialogTitle } from "@/components/ui/dialog";
-import {
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { MessageCircle, MoreHorizontal, User } from "lucide-react";
 
 const profileImageUrl = "https://avatar.iran.liara.run/public/15";
@@ -18,10 +14,10 @@ interface UserProfileDialogProps {
 const SCALE = 0.65;
 
 export function UserProfileDialog({ type }: UserProfileDialogProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? DialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? DialogTitle : InlineDialogTitle;
+  const { DialogHeaderComponent, DialogTitleComponent } = useDialogComponent({
+    dialogType: "dialog",
+    type,
+  });
 
   return (
     <CommonDialog type={type} title="User Profile" scale={SCALE}>

--- a/src/components/dialog/interrupt/ErrorAlert/ErrorAlert.tsx
+++ b/src/components/dialog/interrupt/ErrorAlert/ErrorAlert.tsx
@@ -1,20 +1,5 @@
 import CommonDialog from "@/components/common/CommonDialog";
-import {
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  InlineDialogAction,
-  InlineDialogCancel,
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 
 interface ErrorAlertProps {
   type: "fullScreen" | "card";
@@ -23,18 +8,14 @@ interface ErrorAlertProps {
 const SCALE = 0.8;
 
 export function ErrorAlert({ type }: ErrorAlertProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? AlertDialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? AlertDialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? AlertDialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? AlertDialogFooter : InlineDialogFooter;
-  const DialogActionComponent =
-    type === "fullScreen" ? AlertDialogAction : InlineDialogAction;
-  const DialogCancelComponent =
-    type === "fullScreen" ? AlertDialogCancel : InlineDialogCancel;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+    DialogActionComponent,
+    DialogCancelComponent,
+  } = useDialogComponent({ dialogType: "alert", type });
 
   return (
     <CommonDialog dialogType="alert" type={type} scale={SCALE} title="Error">

--- a/src/components/dialog/interrupt/InfoAlert/InfoAlert.tsx
+++ b/src/components/dialog/interrupt/InfoAlert/InfoAlert.tsx
@@ -1,20 +1,5 @@
 import CommonDialog from "@/components/common/CommonDialog";
-import {
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  InlineDialogAction,
-  InlineDialogCancel,
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 interface InfoAlertProps {
   type: "fullScreen" | "card";
 }
@@ -22,18 +7,14 @@ interface InfoAlertProps {
 const SCALE = 0.8;
 
 export function InfoAlert({ type }: InfoAlertProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? AlertDialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? AlertDialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? AlertDialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? AlertDialogFooter : InlineDialogFooter;
-  const DialogActionComponent =
-    type === "fullScreen" ? AlertDialogAction : InlineDialogAction;
-  const DialogCancelComponent =
-    type === "fullScreen" ? AlertDialogCancel : InlineDialogCancel;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+    DialogActionComponent,
+    DialogCancelComponent,
+  } = useDialogComponent({ dialogType: "alert", type });
 
   return (
     <CommonDialog dialogType="alert" type={type} scale={SCALE} title="Info">

--- a/src/components/dialog/interrupt/SuccessAlert/SuccessAlert.tsx
+++ b/src/components/dialog/interrupt/SuccessAlert/SuccessAlert.tsx
@@ -1,20 +1,5 @@
 import CommonDialog from "@/components/common/CommonDialog";
-import {
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  InlineDialogAction,
-  InlineDialogCancel,
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 
 interface SuccessAlertProps {
   type: "fullScreen" | "card";
@@ -23,18 +8,14 @@ interface SuccessAlertProps {
 const SCALE = 0.8;
 
 export function SuccessAlert({ type }: SuccessAlertProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? AlertDialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? AlertDialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? AlertDialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? AlertDialogFooter : InlineDialogFooter;
-  const DialogActionComponent =
-    type === "fullScreen" ? AlertDialogAction : InlineDialogAction;
-  const DialogCancelComponent =
-    type === "fullScreen" ? AlertDialogCancel : InlineDialogCancel;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+    DialogActionComponent,
+    DialogCancelComponent,
+  } = useDialogComponent({ dialogType: "alert", type });
 
   return (
     <CommonDialog dialogType="alert" type={type} title="Success" scale={SCALE}>

--- a/src/components/dialog/interrupt/UpdateAlert/UpdateAlert.tsx
+++ b/src/components/dialog/interrupt/UpdateAlert/UpdateAlert.tsx
@@ -1,21 +1,6 @@
 import CommonDialog from "@/components/common/CommonDialog";
-import {
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
 import { buttonVariants } from "@/components/ui/button";
-import {
-  InlineDialogAction,
-  InlineDialogCancel,
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 import { DownloadCloudIcon } from "lucide-react";
 
 interface UpdateAlertProps {
@@ -25,18 +10,14 @@ interface UpdateAlertProps {
 const SCALE = 0.8;
 
 export function UpdateAlert({ type }: UpdateAlertProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? AlertDialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? AlertDialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? AlertDialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? AlertDialogFooter : InlineDialogFooter;
-  const DialogActionComponent =
-    type === "fullScreen" ? AlertDialogAction : InlineDialogAction;
-  const DialogCancelComponent =
-    type === "fullScreen" ? AlertDialogCancel : InlineDialogCancel;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+    DialogActionComponent,
+    DialogCancelComponent,
+  } = useDialogComponent({ dialogType: "alert", type });
 
   return (
     <CommonDialog

--- a/src/components/dialog/interrupt/WarningAlert/WarningAlert.tsx
+++ b/src/components/dialog/interrupt/WarningAlert/WarningAlert.tsx
@@ -1,20 +1,5 @@
 import CommonDialog from "@/components/common/CommonDialog";
-import {
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  InlineDialogAction,
-  InlineDialogCancel,
-  InlineDialogDescription,
-  InlineDialogFooter,
-  InlineDialogHeader,
-  InlineDialogTitle,
-} from "@/components/ui/inline-dialog";
+import useDialogComponent from "@/hooks/useDialogComponent";
 
 interface WarningAlertProps {
   type: "fullScreen" | "card";
@@ -23,18 +8,14 @@ interface WarningAlertProps {
 const SCALE = 0.8;
 
 export function WarningAlert({ type }: WarningAlertProps) {
-  const DialogHeaderComponent =
-    type === "fullScreen" ? AlertDialogHeader : InlineDialogHeader;
-  const DialogTitleComponent =
-    type === "fullScreen" ? AlertDialogTitle : InlineDialogTitle;
-  const DialogDescriptionComponent =
-    type === "fullScreen" ? AlertDialogDescription : InlineDialogDescription;
-  const DialogFooterComponent =
-    type === "fullScreen" ? AlertDialogFooter : InlineDialogFooter;
-  const DialogActionComponent =
-    type === "fullScreen" ? AlertDialogAction : InlineDialogAction;
-  const DialogCancelComponent =
-    type === "fullScreen" ? AlertDialogCancel : InlineDialogCancel;
+  const {
+    DialogHeaderComponent,
+    DialogTitleComponent,
+    DialogDescriptionComponent,
+    DialogFooterComponent,
+    DialogActionComponent,
+    DialogCancelComponent,
+  } = useDialogComponent({ dialogType: "alert", type });
 
   return (
     <CommonDialog dialogType="alert" type={type} title="Warning" scale={SCALE}>

--- a/src/hooks/useDialogComponent.ts
+++ b/src/hooks/useDialogComponent.ts
@@ -1,8 +1,23 @@
 import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
   AlertDialogFooter,
   AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { DialogFooter, DialogHeader } from "@/components/ui/dialog";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import {
   InlineDialogAction,
   InlineDialogCancel,
@@ -12,69 +27,72 @@ import {
   type InlineDialogProps,
   InlineDialogTitle,
 } from "@/components/ui/inline-dialog";
-import {
-  AlertDialog,
-  AlertDialogAction,
-  type AlertDialogActionProps,
-  AlertDialogCancel,
-  type AlertDialogCancelProps,
-  AlertDialogContent,
-  type AlertDialogContentProps,
-  AlertDialogDescription,
-  type AlertDialogDescriptionProps,
-  type AlertDialogProps,
-  AlertDialogTitle,
-  type AlertDialogTitleProps,
-  AlertDialogTrigger,
-  type AlertDialogTriggerProps,
+import type {
+  AlertDialogActionProps,
+  AlertDialogCancelProps,
+  AlertDialogContentProps,
+  AlertDialogDescriptionProps,
+  AlertDialogProps,
+  AlertDialogTitleProps,
+  AlertDialogTriggerProps,
 } from "@radix-ui/react-alert-dialog";
-import {
-  Dialog,
-  DialogContent,
-  type DialogContentProps,
-  DialogDescription,
-  type DialogDescriptionProps,
-  type DialogProps,
-  DialogTitle,
-  type DialogTitleProps,
-  DialogTrigger,
+import type {
+  DialogContentProps,
+  DialogDescriptionProps,
+  DialogProps,
+  DialogTitleProps,
+  DialogTriggerProps,
 } from "@radix-ui/react-dialog";
 
 interface DialogComponentProps {
   dialogType: "dialog" | "alert";
   type: "fullScreen" | "card";
 }
-type DialogComponentType<T> =
-  | React.FC<T>
-  | React.ForwardRefExoticComponent<
-      Omit<T & React.RefAttributes<unknown>, "ref">
-    >;
+
+type DialogComponentType<
+  T,
+  K extends HTMLElement = HTMLDivElement,
+  withOmit extends boolean = true,
+> = React.ForwardRefExoticComponent<
+  withOmit extends false
+    ? T
+    : Omit<T & React.RefAttributes<K>, "ref"> & React.RefAttributes<K>
+>;
 
 type ComponentWithDisplayName = {
   ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>): JSX.Element;
   displayName: string;
 };
 
+type InlineComponentType = ({
+  children,
+  className,
+}: InlineDialogProps) => JSX.Element;
+
 type DialogComponents = {
-  DialogComponent: DialogComponentType<AlertDialogProps | DialogProps>;
-  DialogTriggerComponent: DialogComponentType<AlertDialogTriggerProps>;
-  DialogContentComponent: DialogComponentType<
-    AlertDialogContentProps | DialogContentProps
-  >;
-  DialogHeaderComponent:
-    | ComponentWithDisplayName
-    | (({ children, className }: InlineDialogProps) => JSX.Element);
-  DialogTitleComponent: DialogComponentType<
-    AlertDialogTitleProps | DialogTitleProps
-  >;
-  DialogDescriptionComponent: DialogComponentType<
-    AlertDialogDescriptionProps | DialogDescriptionProps
-  >;
-  DialogFooterComponent:
-    | ComponentWithDisplayName
-    | (({ children, className }: InlineDialogProps) => JSX.Element);
-  DialogActionComponent: DialogComponentType<AlertDialogActionProps>;
-  DialogCancelComponent: DialogComponentType<AlertDialogCancelProps>;
+  DialogComponent: React.FC<AlertDialogProps> | React.FC<DialogProps>;
+  DialogTriggerComponent:
+    | DialogComponentType<AlertDialogTriggerProps, HTMLButtonElement, false>
+    | DialogComponentType<DialogTriggerProps, HTMLButtonElement, false>;
+  DialogContentComponent:
+    | DialogComponentType<AlertDialogContentProps>
+    | DialogComponentType<DialogContentProps>;
+  DialogHeaderComponent: ComponentWithDisplayName | InlineComponentType;
+  DialogTitleComponent:
+    | DialogComponentType<AlertDialogTitleProps, HTMLHeadingElement>
+    | DialogComponentType<DialogTitleProps, HTMLHeadingElement>
+    | InlineComponentType;
+  DialogDescriptionComponent:
+    | DialogComponentType<AlertDialogDescriptionProps, HTMLParagraphElement>
+    | DialogComponentType<DialogDescriptionProps, HTMLParagraphElement>
+    | InlineComponentType;
+  DialogFooterComponent: ComponentWithDisplayName | InlineComponentType;
+  DialogActionComponent:
+    | DialogComponentType<AlertDialogActionProps, HTMLButtonElement>
+    | InlineComponentType;
+  DialogCancelComponent:
+    | DialogComponentType<AlertDialogCancelProps, HTMLButtonElement>
+    | InlineComponentType;
 };
 
 export default function useDialogComponent({
@@ -107,17 +125,21 @@ export default function useDialogComponent({
     };
   }
 
-  return {
-    DialogComponent: Dialog,
-    DialogTriggerComponent: DialogTrigger,
-    DialogContentComponent: DialogContent,
-    DialogHeaderComponent: isFullScreen ? DialogHeader : InlineDialogHeader,
-    DialogTitleComponent: isFullScreen ? DialogTitle : InlineDialogTitle,
-    DialogDescriptionComponent: isFullScreen
-      ? DialogDescription
-      : InlineDialogDescription,
-    DialogFooterComponent: isFullScreen ? DialogFooter : InlineDialogFooter,
-    DialogActionComponent: InlineDialogAction,
-    DialogCancelComponent: InlineDialogCancel,
-  };
+  if (dialogType === "dialog") {
+    return {
+      DialogComponent: Dialog,
+      DialogTriggerComponent: DialogTrigger,
+      DialogContentComponent: DialogContent,
+      DialogHeaderComponent: isFullScreen ? DialogHeader : InlineDialogHeader,
+      DialogTitleComponent: isFullScreen ? DialogTitle : InlineDialogTitle,
+      DialogDescriptionComponent: isFullScreen
+        ? DialogDescription
+        : InlineDialogDescription,
+      DialogFooterComponent: isFullScreen ? DialogFooter : InlineDialogFooter,
+      DialogActionComponent: InlineDialogAction,
+      DialogCancelComponent: InlineDialogCancel,
+    };
+  }
+
+  return {} as DialogComponents;
 }

--- a/src/hooks/useDialogComponent.ts
+++ b/src/hooks/useDialogComponent.ts
@@ -125,21 +125,17 @@ export default function useDialogComponent({
     };
   }
 
-  if (dialogType === "dialog") {
-    return {
-      DialogComponent: Dialog,
-      DialogTriggerComponent: DialogTrigger,
-      DialogContentComponent: DialogContent,
-      DialogHeaderComponent: isFullScreen ? DialogHeader : InlineDialogHeader,
-      DialogTitleComponent: isFullScreen ? DialogTitle : InlineDialogTitle,
-      DialogDescriptionComponent: isFullScreen
-        ? DialogDescription
-        : InlineDialogDescription,
-      DialogFooterComponent: isFullScreen ? DialogFooter : InlineDialogFooter,
-      DialogActionComponent: InlineDialogAction,
-      DialogCancelComponent: InlineDialogCancel,
-    };
-  }
-
-  return {} as DialogComponents;
+  return {
+    DialogComponent: Dialog,
+    DialogTriggerComponent: DialogTrigger,
+    DialogContentComponent: DialogContent,
+    DialogHeaderComponent: isFullScreen ? DialogHeader : InlineDialogHeader,
+    DialogTitleComponent: isFullScreen ? DialogTitle : InlineDialogTitle,
+    DialogDescriptionComponent: isFullScreen
+      ? DialogDescription
+      : InlineDialogDescription,
+    DialogFooterComponent: isFullScreen ? DialogFooter : InlineDialogFooter,
+    DialogActionComponent: InlineDialogAction,
+    DialogCancelComponent: InlineDialogCancel,
+  };
 }


### PR DESCRIPTION
- Close #99 

## What is this PR? 🔍

- Feature : use useDialogComponent hook
- issue : #99 

## Changes 📝
- use useDialogComponent hook instead of if conditional statement
- Type
   1. Trigger/Content/Title/Description/Action/Cancel
       - Only Trigger doesn't use the `Omit` utility, so I added a conditional type in the third generic parameter (`withOmit`) to handle this case
      ```
      type DialogComponentType<
        T,
        K extends HTMLElement = HTMLDivElement,
        withOmit extends boolean = true,
      > = React.ForwardRefExoticComponent<
        withOmit extends false
          ? T
          : Omit<T & React.RefAttributes<K>, "ref"> & React.RefAttributes<K>
      >;
      ```
   3. Header/Footer
      ```
      type ComponentWithDisplayName = {
        ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>): JSX.Element;
        displayName: string;
      };
      ```
   4. InlineDialog
      ```
      type InlineComponentType = ({
        children,
        className,
      }: InlineDialogProps) => JSX.Element;
      ```
<!-- Describe your changes -->

## ScreenShot 📷

<!-- Images or GIFs showcasing the developed feature -->


## Precaution

<!-- ## ✔️ Please check if the PR fulfills these requirements

- [ ] It's submitted to the correct branch, not the `develop` branch unconditionally?
- [ ] If on a hotfix branch, ensure it targets `main`?
- [ ] There are no warning message when you run `yarn lint` -->
